### PR TITLE
Extract logic from the original VraiShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Scratchpads are files that are supposed to have tests and experiments, work
+# in progress hence they are not commited into the repository
+*.d/999scratchpad.sh

--- a/bashrc.d/000-aliases-common.sh
+++ b/bashrc.d/000-aliases-common.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+alias cls='clear'
+# -p Forces vim to open files in tabs
+alias vim='vim -p'
+alias grep='grep --color'
+alias grep='zgrep --color'
+
+case "$(uname -s)" in
+    Darwin*)
+        # Easily reset the launchpad layout
+        alias launchpad_reset='defaults write com.apple.dock ResetLaunchPad -bool true; killall Dock'
+        ;;
+    Linux*)
+        # --color Adds colored output
+        # -N Removes quotes from names with spaces
+        alias ls='ls --color -N'
+
+        # Makes it so you can open files with `open` in WSL
+        if uname -r | grep -i microsoft > /dev/null; then
+            alias open="cmd.exe /C start"
+        fi
+        ;;
+esac

--- a/bashrc.d/001-prompt.sh
+++ b/bashrc.d/001-prompt.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Custom/smart prompt with the following format:
+#     {rc} [pwd]
+#     dateTime user@host ?>
+#
+# Where:
+#     rc = return code of the previous command
+#     pwd = full path of the present working directory
+#     dateTime = date and time in format YYYY/MM/DD@hh:mm:ssTZ
+#     user = current user
+#     host = the current host (cnan be personalized with $CUSTOM_PROMPT_HOST)
+#
+# The SC2034 warning is being disabled as the variables are kept for reference
+__customGeneratePrompt() {
+    _VRAI_SHELL_EXIT="$?"
+    
+    if [ -z "$CUSTOM_PROMPT_HOST" ]; then
+        _VRAI_SHELL_HOST_NAME='\h'
+    else
+        _VRAI_SHELL_HOST_NAME="$CUSTOM_PROMPT_HOST"
+    fi
+    
+    # shellcheck disable=SC2016
+    _VRAI_SHELL_RED='\[$(tput setaf 1)\]'
+    # shellcheck disable=SC2016
+    _VRAI_SHELL_GREEN='\[$(tput setaf 2)\]'
+    # shellcheck disable=SC2016,SC2034
+    _VRAI_SHELL_BLUE='\[$(tput setaf 4)\]'
+
+    # shellcheck disable=SC2016
+    _VRAI_SHELL_CYAN='\[$(tput setaf 6)\]'
+    # shellcheck disable=SC2016
+    _VRAI_SHELL_YELLOW='\[$(tput setaf 3)\]'
+    # shellcheck disable=SC2016
+    _VRAI_SHELL_MAGENTA='\[$(tput setaf 5)\]'
+    
+    # shellcheck disable=SC2016,SC2034
+    _VRAI_SHELL_BOLD='\[$(tput bold)\]'
+    # shellcheck disable=SC2016
+    _VRAI_SHELL_RESET='\[$(tput sgr0)\]'
+    
+    _VRAI_SHELL_CPWD="[$_VRAI_SHELL_YELLOW\$PWD$_VRAI_SHELL_RESET]"
+    _VRAI_SHELL_DATE_TIME="$_VRAI_SHELL_MAGENTA\D{%G/%m/%d@%T%Z}$_VRAI_SHELL_RESET"
+    _VRAI_SHELL_HOST_USER="$_VRAI_SHELL_CYAN\u@$_VRAI_SHELL_HOST_NAME$_VRAI_SHELL_RESET"
+    
+    if [ $_VRAI_SHELL_EXIT != 0 ]; then
+        _VRAI_SHELL_RC="{$_VRAI_SHELL_RED$_VRAI_SHELL_EXIT$_VRAI_SHELL_RESET}"
+    else
+        _VRAI_SHELL_RC="{$_VRAI_SHELL_GREEN$_VRAI_SHELL_EXIT$_VRAI_SHELL_RESET}"
+    fi
+    
+    export PS1="$_VRAI_SHELL_RC $_VRAI_SHELL_CPWD\n$_VRAI_SHELL_DATE_TIME $_VRAI_SHELL_HOST_USER \\$> "
+
+    # This is to solve warning SC3043, /bin/sh does not support
+    # `local` so I'm simulating that behavior here
+    unset _VRAI_SHELL_BLUE _VRAI_SHELL_BOLD _VRAI_SHELL_CPWD _VRAI_SHELL_CYAN _VRAI_SHELL_DATE_TIME \
+        _VRAI_SHELL_EXIT _VRAI_SHELL_GREEN _VRAI_SHELL_HOST_NAME _VRAI_SHELL_HOST_USER \
+        _VRAI_SHELL_MAGENTA _VRAI_SHELL_RED _VRAI_SHELL_RESET _VRAI_SHELL_YELLOW
+}
+PROMPT_COMMAND=__customGeneratePrompt

--- a/profile.d/000-functions-for-environment-variables.sh
+++ b/profile.d/000-functions-for-environment-variables.sh
@@ -1,0 +1,114 @@
+# -----------------------------------------------------------------------------#
+#  Author: Vraiment                                                            #
+#                                                                              #
+# These are a set of useful shell functions/commands to manage environment     #
+# variables that contain a list of things, the main example would be the $PATH #
+# variable, but is not limited to that (ex: Java's $CLASSPATH)                 #
+# -----------------------------------------------------------------------------#
+
+# Lists the entries in the variable with the name of the first argument
+# ex: lsevar PATH
+function lsevar {
+    if [[ $# -ne 1 || -z ${!1+x} ]]; then
+        return "$(false)"
+    fi
+
+    echo "${!1}" | tr ':' "\n"
+}
+
+# Verifies if the second argument is in the variable with the name of the first argument
+# ex: grepevar PATH /bin
+function grepevar {
+    if [ $# -ne 2 ]; then
+        return "$(false)"
+    fi
+
+    lsevar "$1" | grep "^$2$"
+}
+
+# Adds a new entry in the environment variable at the beginning of the variable
+# ex: evarprepend PATH $HOME/bin
+function evarprepend {
+    if [ $# -ne 2 ]; then
+        return "$(false)"
+    fi
+
+    if [ -z "${!1}" ]; then
+        eval "$1=\$2"
+    else
+        eval "$1=\$2:\${!1}"
+    fi
+}
+
+# Adds a new entry in the environment variable at the beginning of the variable
+# ex: evarappend PATH $HOME/bin
+function evarappend {
+    if [ $# -ne 2 ]; then
+        return "$(false)"
+    fi
+
+    if [ -z "${!1}" ]; then
+        eval "$1=\$2"
+    else
+        eval "$1=\${!1}:\$2"
+    fi
+}
+
+# Removes all duplicate entries from the environment variable leaving the first appearance
+# ex: uniqevar PATH
+function uniqevar {
+    if [[ $# -ne 1 || -z ${!1+x} ]]; then
+        return "$(false)"
+    fi
+
+    local entries
+    for entry in $(lsevar "$1"); do
+        if (grepevar entries "$entry") > /dev/null; then
+            continue
+        fi
+
+        evarappend entries "$entry"
+    done
+
+    eval "$1=\$entries"
+}
+
+# PATH related commands
+
+# Lists the entries in the PATH variable
+# ex: lspath
+function lspath {
+    lsevar PATH
+}
+
+# Verifies if the second argument is in the PATH variable
+# ex: greppath /bin
+function greppath {
+    grepevar PATH "$1"
+}
+
+# Removes all duplicate entries from the PATH environment variable leaving the first appearance
+# ex: uniqpath
+function uniqpath {
+    uniqevar PATH
+}
+
+# Adds the first argument to the front of PATH if is not present
+# ex: pathprepend $HOME/bin
+function pathprepend {
+    if [[ $# -ne 1 || $(greppath "$1") ]]; then
+        return 1
+    fi
+
+    evarprepend PATH "$1"
+}
+
+# Adds the first argument to the back of PATH if is not present
+# ex: pathappend /usr/local/bin
+function pathappend {
+    if [[ $# -ne 1 || $(greppath "$1") ]]; then
+        return 1
+    fi
+
+    evarappend PATH "$1"
+}

--- a/profile.d/001-environment-common.sh
+++ b/profile.d/001-environment-common.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Forces things like git to use vim if vim is available
+if type vim > /dev/null 2>&1; then
+    export EDITOR=vim
+fi
+
+# Variables per operating system
+case "$(uname -s)" in
+    Darwin*)
+        # Makes so "ls" output is colored
+        export CLICOLOR=1
+        export BASH_SILENCE_DEPRECATION_WARNING=1
+        ;;
+esac
+
+# WSL specific environment variables
+if uname -a | grep -i microsoft > /dev/null; then
+    evarappend WIN_PATH "/mnt/c/Windows/System32"
+    evarappend WIN_PATH "/mnt/c/Windows"
+    evarappend WIN_PATH "/mnt/c/Program Files/dotnet" # For having the dotnet cli
+    export WIN_PATH
+fi
+
+# Set the colors for LS
+export LS_COLORS="di=34:ln=35:so=31:pi=36:ex=32:bd=30;46:cd=30;46:su=32:sg=32:tw=34;46:ow=34"
+
+# Ensure the history size is huge
+export HISTSIZE=10000
+
+# Protect against the log4j nonsense
+export JAVA_TOOL_OPTIONS="-Dlog4j2.formatMsgNoLookups=true ${JAVA_TOOL_OPTIONS}"
+
+# For automatically managing the SSH agent
+if command -v keychain > /dev/null; then
+    keychain -q --nogui "$HOME/.ssh/id_rsa"
+    # The following sourced file has the env variables for the SSH agent
+    if [ -f "$HOME/.keychain/$(hostname)-sh" ]; then
+        # shellcheck disable=SC1090
+        . "$HOME/.keychain/$(hostname)-sh"
+    fi
+fi

--- a/profile.d/002-sdkman.sh
+++ b/profile.d/002-sdkman.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Initialize sdkman
+SDKMAN_DIR="$HOME/.sdkman"
+if [ -d "$SDKMAN_DIR" ]; then
+    export SDKMAN_DIR
+    # shellcheck disable=SC1091
+    [ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ] && . "${SDKMAN_DIR}/bin/sdkman-init.sh"
+fi

--- a/profile.d/010-path-common.sh
+++ b/profile.d/010-path-common.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Adds user's personal bin directory
+if [ -d "$HOME/bin" ] ; then
+    pathprepend "$HOME/bin"
+fi
+
+# Add users's personal local bin directory
+if [ -d "$HOME/.local/bin" ] ; then
+    pathprepend "$HOME/.local/bin"
+fi
+
+# Tools installed from DotNet CLI
+if [ -d "$HOME/.dotnet/tools" ]; then
+    pathprepend "$HOME/.dotnet/tools"
+fi

--- a/profile.d/011-path-nvm.sh
+++ b/profile.d/011-path-nvm.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# NVM is a bunch of functions rather than a $PATH entry
+# but is the best place I can think to place this
+if [ -s "$HOME/.nvm" ]; then
+    export NVM_DIR="$HOME/.nvm"
+
+    if [ -s "$NVM_DIR/nvm.sh" ]; then
+        # shellcheck disable=SC1091
+        . "$NVM_DIR/nvm.sh"
+    fi
+fi

--- a/profile.d/012-path-rbenv.sh
+++ b/profile.d/012-path-rbenv.sh
@@ -1,0 +1,26 @@
+# Configure "rbenv", for version 1.1.2
+if [ -d "$HOME/.rbenv/bin" ]; then
+    export PATH="$HOME/.rbenv/bin:${PATH}"
+fi
+
+if [[ $(type -t rbenv) == "file" ]]; then
+    export PATH="$HOME/.rbenv/shims:${PATH}"
+    export RBENV_SHELL=bash
+
+    command rbenv rehash 2>/dev/null
+
+    rbenv() {
+        local command
+        command="${1:-}"
+        if [ "$#" -gt 0 ]; then
+            shift
+        fi
+
+        case "$command" in
+        rehash|shell)
+            eval "$(rbenv "sh-$command" "$@")";;
+        *)
+            command rbenv "$command" "$@";;
+        esac
+    }
+fi

--- a/profile.d/013-path-vscode.sh
+++ b/profile.d/013-path-vscode.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -d "/Applications/Visual Studio Code.app/Contents/Resources/app/bin" ]; then
+    pathprepend "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+fi

--- a/profile.d/014-path-homebrew.sh
+++ b/profile.d/014-path-homebrew.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -d "/opt/local/bin" ]; then
+    pathprepend "/opt/local/bin"
+fi
+
+if [ -d "/opt/homebrew/bin" ]; then
+    pathprepend "/opt/homebrew/bin"
+fi

--- a/validate.sh
+++ b/validate.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+set -o pipefail # Propagate exit code on a pipeline
+set -x # Print commands and their arguments as they are executed.
+
+function main() {
+    ensure-shellcheck
+    validate-files
+}
+
+function ensure-shellcheck() {
+    if ! command -v shellcheck; then
+        >&2 echo shellcheck not found
+        exit 1
+    fi
+}
+
+function validate-files() {
+    local file_list files_path files
+
+    file_list=(
+        validate.sh # Validate first the validate script itself
+        bash_profile.d/*
+        bashrc.d/*
+        profile.d/*
+    )
+    readonly file_list
+
+    files_path=$(mktemp)
+    readonly files_path
+
+    # I need a mechanism to skip files and Bash, asinine as it is, requires a very convoluted
+    # way to acomplish it, put them into a file skipping the ones I don't want and then use
+    # that file as an argument list.
+    printf "%s\n" "${file_list[@]}" \
+        | grep -v '^profile.d/000-functions-for-environment-variables.sh$' \
+        | grep -v '^profile.d/012-path-rbenv.sh$' \
+        > "$files_path"
+
+    readarray -t files < "$files_path"
+    readonly files
+
+    rm "$files_path"
+
+    shellcheck "${files[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
This is the original logic coming from [vraishell@06a9818f67f5ea7a9911bf5880a0158ce3f96bd9](https://github.com/Vraiment/vraishell/commit/06a9818f67f5ea7a9911bf5880a0158ce3f96bd9), here is a way to validate most of the files (with the exception of `profile.d/002-sdkman.sh`):

```
git diff 06a9818:aliases/000common.sh plugins/vraishell-vraiment/bashrc.d/000-aliases-common.sh
git diff 06a9818:environment/000common.sh plugins/vraishell-vraiment/profile.d/001-environment-common.sh
git diff 06a9818:functions/env-variables.sh plugins/vraishell-vraiment/profile.d/000-functions-for-environment-variables.sh
git diff 06a9818:functions/prompt.sh plugins/vraishell-vraiment/bashrc.d/001-prompt.sh
git diff 06a9818:path/000common.sh plugins/vraishell-vraiment/profile.d/010-path-common.sh
git diff 06a9818:path/010nvm.sh plugins/vraishell-vraiment/profile.d/011-path-nvm.sh
git diff 06a9818:path/010rbenv.sh plugins/vraishell-vraiment/profile.d/012-path-rbenv.sh
git diff 06a9818:path/011vscode.sh plugins/vraishell-vraiment/profile.d/013-path-vscode.sh
git diff 06a9818:path/019homebrew.sh plugins/vraishell-vraiment/profile.d/014-path-homebrew.sh
```